### PR TITLE
Added Keycloak OIDC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ docker run -p 8080:8080 ssm-bats-rest-api
 
 Then, the web service is up and running at `localhost:8080`
 
-#### BATS REST API + Fuseki server
+#### BATS REST API + Fuseki server + Keycloak
 
-You can use docker compose to spin up a container for both services (REST API + Fuseki server):
+You can use docker compose to spin up a container for both services (REST API + Fuseki server + Keycloak):
 
 ```
 docker compose up
 ```
+
+A sample Docker image for Keycloak can be found in the Deployments repo and must be built seprately. To activate the OIDC authentication, set the values in the appropriate application-foo.properties file appropriately use the sample values in the base application.properties file.
 
 #### Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,35 @@
 version: '3'
 services:
+  ssm-postgres:
+    image: postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+
+  ssm-keycloak:
+    image: keycloak
+    restart: unless-stopped
+    depends_on:
+      - ssm-postgres
+    ports:
+      - "8080:8080"
+    environment:
+      FEDERATE_LDAP: "true"
+      GOOGLE_CLIENT_ID: 308694469630-7l6odifs3dc88arbh5cia6ud7v4h2suo.apps.googleusercontent.com
+      GOOGLE_IDP: "true"
+      GOOGLE_SECRET: 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
+      HOSTNAME: ssm-keycloak
+      KC_DB: postgres
+      KC_DB_PASSWORD: postgres
+      KC_DB_URL: jdbc:postgresql://ssm-postgres:5432/
+      KC_DB_USERNAME: postgres
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      LDAP_URL: ldaps://ldapu.ornl.gov
+      USERSDN: "dc=ornl,dc=gov"
+
   ssm-fuseki:
     build:
       context: ./src/main/docker
@@ -39,6 +69,7 @@ services:
     depends_on:
       - ssm-fuseki
       - ssm-document-store
+      - ssm-keycloak
     ports:
-      - "8080:8080"
-    command: "java -jar /app.jar --spring.data.mongodb.username=$MONGO_USERNAME --spring.data.mongodb.password=$MONGO_PASSWORD"
+      - "8082:8080"
+    command: "java -jar /app.jar --spring.data.mongodb.username=$MONGO_USERNAME --spring.data.mongodb.password=$MONGO_PASSWORD --server.port=8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       - "8080:8080"
     environment:
       FEDERATE_LDAP: "true"
-      GOOGLE_CLIENT_ID: 308694469630-7l6odifs3dc88arbh5cia6ud7v4h2suo.apps.googleusercontent.com
+      GOOGLE_CLIENT_ID: XXXXXXXXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.apps.googleusercontent.com
       GOOGLE_IDP: "true"
-      GOOGLE_SECRET: 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
+      GOOGLE_SECRET: XXXXXX-XXXXXXXXXXXXXXXXXXXXXXXXXXXX
       HOSTNAME: ssm-keycloak
       KC_DB: postgres
       KC_DB_PASSWORD: postgres
@@ -27,8 +27,8 @@ services:
       KC_DB_USERNAME: postgres
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      LDAP_URL: ldaps://ldapu.ornl.gov
-      USERSDN: "dc=ornl,dc=gov"
+      LDAP_URL: ldaps://LDAP_HOST
+      USERSDN: "dc=example,dc=com"
 
   ssm-fuseki:
     build:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.4.2</version>
+    <version>2.7.5</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>
@@ -92,6 +92,14 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-hateoas</artifactId>
+    </dependency>
+    <dependency>
+   		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+   		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/SSMBatsRestApiApplication.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/SSMBatsRestApiApplication.java
@@ -10,13 +10,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import gov.ornl.rse.datastreams.ssm_bats_rest_api.configs.ConfigUtils;
 
 /**
  * Main class for Spring App - BATS REST API.
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class SSMBatsRestApiApplication {
 
     /**

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/ApplicationConfig.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/ApplicationConfig.java
@@ -1,5 +1,6 @@
 package gov.ornl.rse.datastreams.ssm_bats_rest_api.configs;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
@@ -61,6 +62,11 @@ public class ApplicationConfig {
     }
 
     /**
+     * The authorization type. Valid values are "none" and "keycloak".
+     */
+    private String authorization;
+
+    /**
      * <p>
      * Hostname + port of the REST API server. Examples:
      * </p>
@@ -77,10 +83,28 @@ public class ApplicationConfig {
     private final Fuseki fuseki = new Fuseki();
 
     /**
+     * Getter for the Authorization type.
+     *
+     * @return The authorization type the API will use.
+     */
+    public AuthorizationType getAuthorization() {
+        return EnumUtils.getEnumIgnoreCase(AuthorizationType.class, authorization);
+    }
+
+    /**
      * @return host for the REST API server
      */
     public String getHost() {
         return host;
+    }
+
+    /**
+     * Setter for the authorization type.
+     *
+     * @param authorization
+     */
+    void setAuthorization(final String authorization) {
+        this.authorization = authorization;
     }
 
     /**

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/AuthorizationType.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/AuthorizationType.java
@@ -1,0 +1,16 @@
+package gov.ornl.rse.datastreams.ssm_bats_rest_api.configs;
+
+/**
+ * The type of authorization the API will apply.
+ *
+ * @author Robert Smith
+ *
+ */
+public enum AuthorizationType {
+
+    /**
+     * NONE- No authorization required.
+     * KEYCLOAK- OIDC authentication through Keycloak.
+    */
+    NONE, KEYCLOAK
+}

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/OIDCLoginSecurityConfig.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/configs/OIDCLoginSecurityConfig.java
@@ -1,0 +1,61 @@
+package gov.ornl.rse.datastreams.ssm_bats_rest_api.configs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * Security configuration for OIDC sign in.
+ *
+ * @author Robert Smith
+ *
+ */
+@EnableWebSecurity
+@Configuration
+public class OIDCLoginSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    /**
+     * Application configuration from application.properties.
+     */
+    @Autowired
+    private ApplicationConfig applicationConfig;
+
+    /**
+     * Spring-boot client registry.
+     */
+    @Autowired(required = false)
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+    /**
+     * Creates the filter chain.
+     *
+     * @param http SpringBoot security object
+     * @throws Exception
+     * */
+    @Override
+    public void configure(final HttpSecurity http) throws Exception {
+
+        // Do nothing if not using keycloak type authorization
+        if (applicationConfig.getAuthorization().equals(AuthorizationType.KEYCLOAK)) {
+
+            // Create a logout handler
+            OidcClientInitiatedLogoutSuccessHandler handler =
+                new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
+            handler.setPostLogoutRedirectUri(applicationConfig.getHost() + "token/");
+
+            // Configure the request matcher to secure all pages except logon
+            http.authorizeRequests(authorizeRequests -> authorizeRequests
+                .antMatchers("/logon").permitAll()
+                .anyRequest().authenticated())
+                .oauth2Login(e -> e.permitAll())
+                .logout(e -> e.logoutSuccessHandler(handler))
+                .oauth2ResourceServer()
+                .jwt();
+        }
+    }
+
+}

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/ErrorControllerImpl.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/ErrorControllerImpl.java
@@ -63,7 +63,6 @@ public class ErrorControllerImpl implements ErrorController {
     /**
      * {@inheritDoc}
      */
-    @Override
     public String getErrorPath() {
         return ERROR_PATH;
     }

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/LoginController.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/LoginController.java
@@ -1,0 +1,52 @@
+package gov.ornl.rse.datastreams.ssm_bats_rest_api.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import gov.ornl.rse.datastreams.ssm_bats_rest_api.configs.ApplicationConfig;
+
+/**
+ * Controller for a page to verify user logged in status and provide a url to
+ * instructions for obtaining a token if not.
+ *
+ * @author Robert Smith
+ *
+ */
+@RestController
+@RequestMapping("/logon")
+public class LoginController {
+
+    /**
+     * Setup Application config.
+     */
+    @Autowired
+    private ApplicationConfig appConfig;
+
+    /**
+     * Returns whether the user is logged in or the url to login with.
+     *
+     * @return A webpage
+     */
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity getLogin() {
+
+        // Get the current user
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        // If the user is logged in the OIDC, give a success message.
+        if (authentication.getPrincipal() instanceof OidcUser) {
+            return new ResponseEntity("Logged in", HttpStatus.OK);
+        }
+
+        // If user isn't logged in with OIDC, give the url for the token page
+        return new ResponseEntity(appConfig.getHost() + "/token", HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/TokenController.java
+++ b/src/main/java/gov/ornl/rse/datastreams/ssm_bats_rest_api/controllers/TokenController.java
@@ -1,0 +1,93 @@
+package gov.ornl.rse.datastreams.ssm_bats_rest_api.controllers;
+
+import java.time.Instant;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+/**
+ * Controller for displaying OIDC tokens.
+ *
+ * @author Robert Smith
+ *
+ */
+@RestController
+@RequestMapping("/token")
+public class TokenController {
+
+    /**
+     * Oauth authentication service.
+    */
+    @Autowired(required = false)
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    /**
+     * Displays the user's token and sample curl usage.
+     *
+     * @return A webpage
+     */
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity getToken() {
+
+        // Get the current user
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        // If the user is an OIDC user, display the OIDC JWT tokens
+        if (authentication.getPrincipal() instanceof OidcUser) {
+
+            // The user information
+            OidcUser user = (OidcUser) authentication.getPrincipal();
+
+            // If the token has expired, delete it from the session and refresh so that
+            // spring security will get a valid one
+            if (user.getIdToken().getExpiresAt().isBefore(Instant.now())) {
+                SecurityContextHolder.getContext().setAuthentication(null);
+                HttpHeaders headers = new HttpHeaders();
+                headers.add("Location", "/token");
+                return new ResponseEntity<String>(headers, HttpStatus.FOUND);
+            }
+
+            // Get the JWT tokens
+            String token = user.getIdToken().getTokenValue();
+            String contents = "Token = " + token;
+            OAuth2AuthorizedClient client =
+                    authorizedClientService.loadAuthorizedClient("keycloak", user.getName());
+            String refreshToken = client.getRefreshToken().getTokenValue();
+            String accessToken = client.getAccessToken().getTokenValue();
+
+            // Construct the return content with the tokens and usage instructions
+            contents = contents + "\n Refresh Token = " + refreshToken + "\n Access Token = "
+                + accessToken
+                + "\n To manually use this token: \n curl -H \"Authorization: Bearer "
+                + token + "\" "
+                + ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString()
+                + "/proflie";
+            return new ResponseEntity(contents, HttpStatus.OK);
+
+        } else if (authentication.getPrincipal() instanceof Jwt) {
+
+            // If the user authenticated with a JWT, echo back the JWT
+            Jwt jwt = (Jwt) authentication.getPrincipal();
+            return new ResponseEntity("\n JWT authenticated \n" + jwt.toString() + "\n",
+                    HttpStatus.OK);
+        }
+
+        // If another authentication method was used, display what it was.
+        return new ResponseEntity("Logged in with: "
+                + authentication.getPrincipal().getClass().toString(),
+                HttpStatus.OK);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,7 @@
 app.host=http://localhost:8080
 app.fuseki.hostname=http://localhost
 app.fuseki.port=3030
+spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 ###############################################################################
 
 ###############################################################################
@@ -47,3 +48,18 @@ spring.profiles.group.dev=dev,docker
 spring.profiles.group.qa=qa,docker
 spring.profiles.group.prod=prod,docker
 spring.profiles.group.localdocker=local,docker
+
+###############################################################################
+# Authentication config
+
+# Valid values are "none" and "keycloak"
+app.authorization=none
+
+# Keycloak config
+#spring.security.oauth2.client.provider.keycloak.issuer-uri=http://ssm-keycloak:8082/realms/ssm
+#Spring.security.oauth2.client.registration.keycloak.client-id=ucams
+#spring.security.oauth2.client.registration.keycloak.client-secret=AocSmf4q3B0UdhessSMft1cecAMp37S8
+#spring.security.oauth2.client.registration.keycloak.scope=openid
+#spring.security.oauth2.resourceserver.jwt.issuer-uri=http://ssm-keycloak:8082/realms/ssm
+#spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://ssm-keycloak:8082/realms/ssm/protocol/openid-connect/certs
+###############################################################################


### PR DESCRIPTION
Added optional Keycloak OIDC authentication with example docker-compose. Note that the catalog service has been moved to port 8082 in the docker-compose so that the Keycloak server is available at the same address both on the host machine and in the docker containers. This is because the Keycloak Docker container was not playing well with different port numbers. In a real deployment, the catalog service can have port 8080 and Keycloak would be made accessible via the hostname of the server.

Also updated Dockerfiles to pull from Docker hub rather than code.ornl.gov.

Addresses issues #1 #2 and #3